### PR TITLE
Fix weird aim input behavior

### DIFF
--- a/gamemodes/bhop/gamemode/cl_init.lua
+++ b/gamemodes/bhop/gamemode/cl_init.lua
@@ -100,7 +100,7 @@ steady_view.Enabled = CreateClientConVar( "kawaii_steady_view", "0", true, false
 hook.Add("CalcViewModelView", "FixPos", function(wep, vm, oldPos, oldAng, pos, ang)
 
 	if steady_view then
-		pos, ang = oldPos, oldAng + Angle( -5, -5, 0 )
+		pos, ang = oldPos, oldAng
 	end
 
 	local suppress_viewpunch_wep = suppress_viewpunch_wep.Enabled:GetBool()
@@ -120,7 +120,7 @@ local function fov(ply, ori, ang, fov, nz, fz)
 	end
 
 	view.origin = ori
-	view.angles = ply:EyeAngles() + Angle( -5, -5, 0 )
+	view.angles = ply:EyeAngles()
 	view.fov = newfov
 
 	return view


### PR DESCRIPTION
Fixes a strange behavior with aim input that causes many issues with the gamemode such as not being able to walk straight, paint not painting at the right spot, being able to gain speed on flat walls, etc.